### PR TITLE
support the latest build of create 0.5.1-f

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ yarn_mappings=1.20.1+build.10
 
 # Create
 # https://modrinth.com/mod/create-fabric/versions
-create_version = 0.5.1-f-build.1335+mc1.20.1
+create_version = 0.5.1-f-build.1417+mc1.20.1
 
 # Development QOL
 # Create supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.


### PR DESCRIPTION
This PR updates the mod to use the latest 0.5.1-f build of create 
[0.5.1-f-build.1417+mc1.20.1](https://modrinth.com/mod/create-fabric/version/0.5.1-f-build.1417+mc1.20.1) 